### PR TITLE
未找到smart-doc配置文件时报错提示 close#5

### DIFF
--- a/src/main/java/com/smartdoc/mojo/BaseDocsGeneratorMojo.java
+++ b/src/main/java/com/smartdoc/mojo/BaseDocsGeneratorMojo.java
@@ -118,7 +118,7 @@ public abstract class BaseDocsGeneratorMojo extends AbstractMojo {
             return;
         }
         if (Objects.nonNull(configFile) && !configFile.exists()) {
-            return;
+            throw new MojoFailureException("can not find configFile: " + configFile.getName());
         }
         getLog().info("Smart-doc Start preparing sources at: " + DateTimeUtil.nowStrTime());
         projectArtifacts = new ArrayList<>();


### PR DESCRIPTION
测试: 未找到配置文件时报错提示并且` BUILD FAILURE`

![11_20201114232151](https://user-images.githubusercontent.com/20562449/99151156-35a72200-26d4-11eb-95eb-0409012767c3.jpg)

