### PR TITLE
生成文档,在开启严格模式时，如果注释不完整，让插件执行mvn生成报错

### DIFF
--- a/src/main/java/com/smartdoc/mojo/ADocMojo.java
+++ b/src/main/java/com/smartdoc/mojo/ADocMojo.java
@@ -44,6 +44,9 @@ public class ADocMojo extends BaseDocsGeneratorMojo {
             AdocDocBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/HtmlMojo.java
+++ b/src/main/java/com/smartdoc/mojo/HtmlMojo.java
@@ -48,6 +48,9 @@ public class HtmlMojo extends BaseDocsGeneratorMojo {
             HtmlApiDocBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/MarkDownMojo.java
+++ b/src/main/java/com/smartdoc/mojo/MarkDownMojo.java
@@ -44,6 +44,9 @@ public class MarkDownMojo extends BaseDocsGeneratorMojo {
             ApiDocBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/OpenApiMojo.java
+++ b/src/main/java/com/smartdoc/mojo/OpenApiMojo.java
@@ -46,6 +46,9 @@ public class OpenApiMojo extends BaseDocsGeneratorMojo {
             OpenApiBuilder.buildOpenApi(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/PostManMojo.java
+++ b/src/main/java/com/smartdoc/mojo/PostManMojo.java
@@ -44,6 +44,9 @@ public class PostManMojo extends BaseDocsGeneratorMojo {
             PostmanJsonBuilder.buildPostmanCollection(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/RpcAdocMojo.java
+++ b/src/main/java/com/smartdoc/mojo/RpcAdocMojo.java
@@ -44,6 +44,9 @@ public class RpcAdocMojo extends BaseDocsGeneratorMojo {
             RpcAdocBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/RpcHtmlMojo.java
+++ b/src/main/java/com/smartdoc/mojo/RpcHtmlMojo.java
@@ -44,6 +44,9 @@ public class RpcHtmlMojo extends BaseDocsGeneratorMojo {
             RpcHtmlBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/RpcMarkdownMojo.java
+++ b/src/main/java/com/smartdoc/mojo/RpcMarkdownMojo.java
@@ -44,6 +44,9 @@ public class RpcMarkdownMojo extends BaseDocsGeneratorMojo {
             RpcMarkdownBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/SwaggerMojo.java
+++ b/src/main/java/com/smartdoc/mojo/SwaggerMojo.java
@@ -24,6 +24,9 @@ public class SwaggerMojo extends BaseDocsGeneratorMojo {
             SwaggerBuilder.buildOpenApi(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/TornaRestMojo.java
+++ b/src/main/java/com/smartdoc/mojo/TornaRestMojo.java
@@ -46,6 +46,9 @@ public class TornaRestMojo extends BaseDocsGeneratorMojo {
             TornaBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/smartdoc/mojo/TornaRpcMojo.java
+++ b/src/main/java/com/smartdoc/mojo/TornaRpcMojo.java
@@ -46,6 +46,9 @@ public class TornaRpcMojo extends BaseDocsGeneratorMojo {
             RpcTornaBuilder.buildApiDoc(apiConfig, javaProjectBuilder);
         } catch (Exception e) {
             getLog().error(e);
+            if (apiConfig.isStrict()) {
+                throw new RuntimeException(e.getMessage());
+            }
         }
     }
 }


### PR DESCRIPTION
如标题，在生成openapi 时，开启了严格模式，如果接口注释不规范，会使mvn 构建失败

```java
@Execute(phase = LifecyclePhase.COMPILE)
@Mojo(name = MojoConstants.OPENAPI_MOJO, requiresDependencyResolution = ResolutionScope.COMPILE)
public class OpenApiMojo extends BaseDocsGeneratorMojo {

    @Override
    public void executeMojo(ApiConfig apiConfig, JavaProjectBuilder javaProjectBuilder) {
        try {
            OpenApiBuilder.buildOpenApi(apiConfig, javaProjectBuilder);
        } catch (Exception e) {
            getLog().error(e);
            if (apiConfig.isStrict()) {
                throw new RuntimeException(e.getMessage());
            }
        }
    }
}
```
